### PR TITLE
Adjust animal column widths

### DIFF
--- a/src/misc-macros.tex
+++ b/src/misc-macros.tex
@@ -152,7 +152,7 @@
 \vspace{-10pt}
 
 \begin{dsaSheetBox}
-    \begin{NiceTabular}{p{3.067cm}|x{3.9cm}|x{0.8cm}|x{0.8cm}|x{0.8cm}|x{0.8cm}|x{0.8cm}|x{0.8cm}|x{0.8cm}|x{0.8cm}|x{0.8cm}|x{0.8cm}|x{0.8cm}|x{0.8cm}|x{0.8cm}}
+    \begin{NiceTabular}{p{3.067cm}|x{3.4cm}|x{0.8cm}|x{0.8cm}|x{0.8cm}|x{1.2cm}|x{0.8cm}|x{0.8cm}|x{0.8cm}|x{0.8cm}|x{0.8cm}|x{0.8cm}|x{0.8cm}|x{0.8cm}|x{0.8cm}}
     \CodeBefore
         \rowcolors{2}{gray!30}{white}
     \Body


### PR DESCRIPTION
The TP column was too narrow to fit an entire TP description. To widen it we can probably take a little space from the rather spacious animal kind column.